### PR TITLE
feat: show internship credits separately in planner total bar

### DIFF
--- a/.sonarcloud.properties
+++ b/.sonarcloud.properties
@@ -1,0 +1,2 @@
+sonar.cpd.exclusions=tests/**
+sonar.exclusions=tests/**,test/e2e/**

--- a/src/app/planner/page.tsx
+++ b/src/app/planner/page.tsx
@@ -105,7 +105,7 @@ export default function PlannerPage() {
         ))}
       </div>
 
-      <div className="mt-2 flex justify-center items-center gap-4">
+      <div className="mt-2 flex flex-wrap justify-center items-center gap-4">
         <Button
           variant="secondary"
           size="default"
@@ -117,19 +117,17 @@ export default function PlannerPage() {
           {' '}
           {t('total-credits')}
         </Button>
-        {totalStageCredits > 0 && (
-          <Button
-            variant="secondary"
-            size="default"
-            className="pointer-events-none select-none cursor-default"
-            tabIndex={-1}
-            data-testid="total-stage-credits"
-          >
-            {totalStageCredits}
-            {' '}
-            {t('stage-credits')}
-          </Button>
-        )}
+        <Button
+          variant="secondary"
+          size="default"
+          className="pointer-events-none select-none cursor-default"
+          tabIndex={-1}
+          data-testid="total-stage-credits"
+        >
+          {totalStageCredits}
+          {' '}
+          {t('stage-credits')}
+        </Button>
         <Button
           variant="default"
           size="default"

--- a/src/app/planner/page.tsx
+++ b/src/app/planner/page.tsx
@@ -16,6 +16,7 @@ import { useCourseStore } from '@/store/courseStore';
 import { useOnboardingStore } from '@/store/onboardingStore';
 import { usePlannerStore } from '@/store/plannerStore';
 import { useSessionStore } from '@/store/sessionStore';
+import { accumulateCreditSplit } from '@/utils/creditUtil';
 import { buildDuplicateCourseSessionIndex } from '@/utils/sessionUtil';
 
 export default function PlannerPage() {
@@ -63,16 +64,17 @@ export default function PlannerPage() {
 
   const years = getYears();
 
-  // Calculate total credits across all sessions
-  const totalCredits = Object.values(sessions).reduce((sum, session) => {
-    return (
-      sum
-      + session.courseInstances.reduce((s, ci) => {
-        const course = courses[ci.courseId];
-        return s + (course?.credits ?? 0);
-      }, 0)
+  // Calculate total credits across all sessions, split by course vs stage
+  const { totalCourseCredits, totalStageCredits }
+    = Object.values(sessions).reduce(
+      (acc, session) => {
+        const split = accumulateCreditSplit(session.courseInstances, courses);
+        acc.totalCourseCredits += split.totalCourseCredits;
+        acc.totalStageCredits += split.totalStageCredits;
+        return acc;
+      },
+      { totalCourseCredits: 0, totalStageCredits: 0 },
     );
-  }, 0);
 
   // Build an index to identify duplicate course sessions
   const duplicateCourseSessionIndex = useMemo(
@@ -111,10 +113,23 @@ export default function PlannerPage() {
           tabIndex={-1}
           data-testid="total-credits"
         >
-          {totalCredits}
+          {totalCourseCredits}
           {' '}
           {t('total-credits')}
         </Button>
+        {totalStageCredits > 0 && (
+          <Button
+            variant="secondary"
+            size="default"
+            className="pointer-events-none select-none cursor-default"
+            tabIndex={-1}
+            data-testid="total-stage-credits"
+          >
+            {totalStageCredits}
+            {' '}
+            {t('stage-credits')}
+          </Button>
+        )}
         <Button
           variant="default"
           size="default"

--- a/src/components/Planner/CoursesList.tsx
+++ b/src/components/Planner/CoursesList.tsx
@@ -82,7 +82,8 @@ const CoursesList: FC<CoursesListProps> = ({
         )
         : (
           <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
-            {t('drag-courses-to-add-course')}
+            <span className="md:hidden">{t('add-course')}</span>
+            <span className="hidden md:inline">{t('drag-courses-to-add-course')}</span>
           </div>
         )}
     </div>

--- a/src/lib/api/types/course.ts
+++ b/src/lib/api/types/course.ts
@@ -8,7 +8,7 @@ export type SearchCourseResult = {
   cycle?: number;
   sessionAvailability: SessionAvailabilityDto[];
   prerequisites: CoursePrerequisiteDto[];
-  type?: 'TRONC' | 'CONCE' | 'CONDI' | 'PROFI' | null;
+  type?: 'TRONC' | 'CONCE' | 'CONDI' | 'PROFI' | 'STAGE' | null;
   typicalSessionIndex?: number | null;
   unstructuredPrerequisite?: string | null;
 };

--- a/src/lib/api/types/program.ts
+++ b/src/lib/api/types/program.ts
@@ -20,7 +20,7 @@ export type ProgramListDto = {
   programTitle: string;
 };
 
-export type CourseRequirementType = 'TRONC' | 'CONCE' | 'CONDI' | 'PROFI';
+export type CourseRequirementType = 'TRONC' | 'CONCE' | 'CONDI' | 'PROFI' | 'STAGE';
 
 export type CourseAvailabilityDto = 'JOUR' | 'SOIR' | 'INTENSIF';
 

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -2,6 +2,7 @@
   "Commons": {
     "credits": "credits",
     "total-credits": "total credits",
+    "stage-credits": "internship credits",
     "credits-short": "cr.",
     "logout": "Sign out",
     "settings": "Settings",

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -74,7 +74,7 @@
     "course-details": "Course details",
     "add-to-favorites": "Add to favorites",
     "remove-from-favorites": "Remove from favorites",
-    "add-course": "Add a course"
+    "add-course": "Tap + to add courses"
   },
   "CourseDetailsPage": {
     "courseOffering": "Offerings",

--- a/src/messages/fr.json
+++ b/src/messages/fr.json
@@ -1,7 +1,8 @@
 {
   "Commons": {
     "credits": "crédits",
-    "total-credits": "crédits au total",
+    "total-credits": "crédits de cours",
+    "stage-credits": "crédits de stage",
     "credits-short": "cr.",
     "logout": "Se déconnecter",
     "settings": "Paramètres",

--- a/src/messages/fr.json
+++ b/src/messages/fr.json
@@ -45,7 +45,7 @@
     },
     "duplicate-course-sessions": "Ce cours est déjà planifié dans les sessions: {sessions}.",
     "no-course-modif-past-session": "Aucune modification autorisée pour cette session passée.",
-    "drag-courses-to-add-course": "Glissez les cours ici pour les ajouter à cette session.",
+    "drag-courses-to-add-course": "Glisser les cours ici pour les ajouter à cette session.",
     "information-course-availability": "Informations sur la disponibilité des cours",
     "courses-availability-not-yet-published": "Les informations sur la disponibilité des cours pour cette session ne sont pas encore publiées par l'école.",
     "prerequisites": "Prérequis: ",
@@ -74,7 +74,7 @@
     "course-details": "Détails du cours",
     "add-to-favorites": "Ajouter aux favoris",
     "remove-from-favorites": "Retirer des favoris",
-    "add-course": "Ajouter un cours"
+    "add-course": "Appuyer sur + pour ajouter des cours"
   },
   "CourseDetailsPage": {
     "courseOffering": "Disponibilité",
@@ -87,13 +87,13 @@
     "noOfferings": "Aucune disponibilité pour le moment.",
     "noPrerequisites": "Aucun préalable n'est listé pour ce cours.",
     "noPrograms": "Aucun programme n'a été trouvé pour ce cours.",
-    "pageDescription": "Recherchez un cours pour voir les détails.",
+    "pageDescription": "Rechercher un cours pour voir les détails.",
     "pageTitle": "Détails du cours",
     "prerequisites": "Préalables",
     "unstructuredPrerequisiteRule": "Règle de préalable additionnelle",
     "requirementType": "catégorie d'exigence",
     "searchCourseLabel": "Trouver un cours",
-    "selectProgramDescription": "Choisissez un programme pour voir les détails de ce cours.",
+    "selectProgramDescription": "Choisir un programme pour voir les détails de ce cours.",
     "selectProgramLabel": "Programme",
     "selectProgramPlaceholder": "Choisir un programme",
     "selectedProgram": "Programme sélectionné",

--- a/src/utils/creditUtil.ts
+++ b/src/utils/creditUtil.ts
@@ -5,7 +5,7 @@ type CreditSplit = {
 
 export function accumulateCreditSplit(
   courseInstances: { courseId: number }[],
-  courses: Record<number, { credits?: number | null; type?: string | null }>,
+  courses: Record<number, { credits?: number | null; type?: string | null; title?: string | null }>,
 ): CreditSplit {
   return courseInstances.reduce(
     (acc, inst) => {
@@ -16,7 +16,7 @@ export function accumulateCreditSplit(
 
       const credits = course.credits ?? 0;
 
-      if (course.type === 'STAGE') {
+      if (course.type === 'STAGE' || course.title?.startsWith('Stage')) {
         acc.totalStageCredits += credits;
       } else {
         acc.totalCourseCredits += credits;

--- a/src/utils/creditUtil.ts
+++ b/src/utils/creditUtil.ts
@@ -1,0 +1,29 @@
+type CreditSplit = {
+  totalCourseCredits: number;
+  totalStageCredits: number;
+};
+
+export function accumulateCreditSplit(
+  courseInstances: { courseId: number }[],
+  courses: Record<number, { credits?: number | null; type?: string | null }>,
+): CreditSplit {
+  return courseInstances.reduce(
+    (acc, inst) => {
+      const course = courses[inst.courseId];
+      if (!course) {
+        return acc;
+      }
+
+      const credits = course.credits ?? 0;
+
+      if (course.type === 'STAGE') {
+        acc.totalStageCredits += credits;
+      } else {
+        acc.totalCourseCredits += credits;
+      }
+
+      return acc;
+    },
+    { totalCourseCredits: 0, totalStageCredits: 0 },
+  );
+}

--- a/src/utils/sessionUtil.ts
+++ b/src/utils/sessionUtil.ts
@@ -229,6 +229,10 @@ export const isCourseAvailableInSession = (
     return false;
   }
 
+  if (course.type === 'STAGE') {
+    return true;
+  }
+
   const sessionCode = generateSessionCode(sessionTerm, sessionYear);
   return course.availability.includes(sessionCode);
 };

--- a/src/utils/sessionUtil.ts
+++ b/src/utils/sessionUtil.ts
@@ -229,7 +229,7 @@ export const isCourseAvailableInSession = (
     return false;
   }
 
-  if (course.type === 'STAGE') {
+  if (course.type === 'STAGE' || course.title.startsWith('Stage')) {
     return true;
   }
 

--- a/tests/assets/courses.ts
+++ b/tests/assets/courses.ts
@@ -55,4 +55,17 @@ export const TEST_COURSES: Record<string, TestCourse> = {
     sessionTerm: TermEnum.E,
     sessionYear: CURRENT_YEAR,
   },
+  // stage placeholders: linked to every active cycle-1 program
+  STG001: {
+    code: 'STG001',
+    credits: 9,
+    sessionTerm: TermEnum.E,
+    sessionYear: CURRENT_YEAR,
+  },
+  STG001_A: {
+    code: 'STG001',
+    credits: 9,
+    sessionTerm: TermEnum.A,
+    sessionYear: CURRENT_YEAR,
+  },
 };

--- a/tests/assets/selectors.ts
+++ b/tests/assets/selectors.ts
@@ -29,6 +29,7 @@ export const selectors = {
 
   // Credits
   totalCredits: '[data-testid="total-credits"]',
+  totalStageCredits: '[data-testid="total-stage-credits"]',
   sessionCredits: (sessionTerm: TermEnum, sessionYear: number) =>
     `[data-testid="session-${sessionTerm}-${sessionYear}-credits"]`,
 

--- a/tests/e2e/fixtures/mock/data/course-search-results.ts
+++ b/tests/e2e/fixtures/mock/data/course-search-results.ts
@@ -293,4 +293,29 @@ export const COURSE_SEARCH_RESULTS: Record<string, SearchCoursesDto> = {
     total: 1,
     hasMore: false,
   },
+  STG001: {
+    courses: [
+      {
+        id: 9000001,
+        code: 'STG001',
+        title: 'Stage I',
+        credits: 9,
+        cycle: 1,
+        type: 'STAGE',
+        sessionAvailability: [
+          {
+            sessionCode: `E${new Date().getFullYear()}`,
+            availability: ['JOUR'],
+          },
+          {
+            sessionCode: `A${new Date().getFullYear()}`,
+            availability: ['JOUR'],
+          },
+        ],
+        prerequisites: [],
+      },
+    ],
+    total: 1,
+    hasMore: false,
+  },
 };

--- a/tests/e2e/fixtures/mock/data/program-courses.ts
+++ b/tests/e2e/fixtures/mock/data/program-courses.ts
@@ -3246,6 +3246,43 @@ export const PROGRAM_COURSES_RESPONSE: ProgramCoursesResponseDto = {
           typicalSessionIndex: 8,
           unstructuredPrerequisite: '',
         },
+        {
+          id: 9000001,
+          code: 'STG001',
+          title: 'Stage I',
+          credits: 9,
+          cycle: 1,
+          sessionAvailability: [
+            {
+              sessionCode: 'E2025',
+              availability: [
+                'JOUR',
+              ],
+            },
+            {
+              sessionCode: 'A2025',
+              availability: [
+                'JOUR',
+              ],
+            },
+            {
+              sessionCode: 'E2026',
+              availability: [
+                'JOUR',
+              ],
+            },
+            {
+              sessionCode: 'A2026',
+              availability: [
+                'JOUR',
+              ],
+            },
+          ],
+          prerequisites: [],
+          type: 'STAGE',
+          typicalSessionIndex: null,
+          unstructuredPrerequisite: null,
+        },
       ],
     },
     {
@@ -5972,6 +6009,43 @@ export const PROGRAM_COURSES_RESPONSE: ProgramCoursesResponseDto = {
           prerequisites: [],
           type: 'CONCE',
           typicalSessionIndex: 8,
+          unstructuredPrerequisite: null,
+        },
+        {
+          id: 9000001,
+          code: 'STG001',
+          title: 'Stage I',
+          credits: 9,
+          cycle: 1,
+          sessionAvailability: [
+            {
+              sessionCode: 'E2025',
+              availability: [
+                'JOUR',
+              ],
+            },
+            {
+              sessionCode: 'A2025',
+              availability: [
+                'JOUR',
+              ],
+            },
+            {
+              sessionCode: 'E2026',
+              availability: [
+                'JOUR',
+              ],
+            },
+            {
+              sessionCode: 'A2026',
+              availability: [
+                'JOUR',
+              ],
+            },
+          ],
+          prerequisites: [],
+          type: 'STAGE',
+          typicalSessionIndex: null,
           unstructuredPrerequisite: null,
         },
       ],

--- a/tests/e2e/specs/credits.spec.ts
+++ b/tests/e2e/specs/credits.spec.ts
@@ -87,7 +87,7 @@ test.describe('Credits Management', () => {
     );
   });
 
-  test('should hide internship credit total when no Stage courses are in the plan', async ({ page }) => {
+  test('should show zero internship credits when no Stage courses are in the plan', async ({ page }) => {
     const course = TEST_COURSES.LOG240;
 
     await searchCourseInSidebar(page, course.code);
@@ -95,6 +95,7 @@ test.describe('Credits Management', () => {
 
     const totalStageCredits = page.locator(selectors.totalStageCredits);
 
-    await expect(totalStageCredits).not.toBeVisible({ timeout: 15000 });
+    await expect(totalStageCredits).toBeVisible({ timeout: 15000 });
+    await expect(totalStageCredits).toContainText('0');
   });
 });

--- a/tests/e2e/specs/credits.spec.ts
+++ b/tests/e2e/specs/credits.spec.ts
@@ -2,9 +2,11 @@ import { expect, test } from '@playwright/test';
 import { TEST_COURSES } from '../../assets/courses';
 import { selectors } from '../../assets/selectors';
 import { addCourseToSession, deleteCourse, searchCourseInSidebar } from '../fixtures/course';
+import { reliableDragAndDrop } from '../fixtures/dnd';
 import { selectProgram } from '../fixtures/program';
 import { setupTestPage } from '../fixtures/setup';
 
+const STAGE_CREDITS_LABEL = 'internship credits';
 const CREDITS_LABEL = 'credits';
 
 test.describe('Credits Management', () => {
@@ -47,5 +49,52 @@ test.describe('Credits Management', () => {
       `0 ${CREDITS_LABEL}`,
       { timeout: 15000 },
     );
+  });
+
+  test('should show internship credit total when a Stage course is added', async ({ page }) => {
+    const course = TEST_COURSES.STG001;
+
+    await searchCourseInSidebar(page, course.code);
+    await addCourseToSession(page, course);
+
+    const totalStageCredits = page.locator(selectors.totalStageCredits);
+
+    await expect(totalStageCredits).toBeVisible({ timeout: 15000 });
+    await expect(totalStageCredits).toHaveText(
+      `${course.credits} ${STAGE_CREDITS_LABEL}`,
+      { timeout: 15000 },
+    );
+  });
+
+  test('should accumulate stage credits when two Stage courses are added', async ({ page }) => {
+    const courseE = TEST_COURSES.STG001;
+    const courseA = TEST_COURSES.STG001_A;
+
+    await searchCourseInSidebar(page, courseE.code);
+    await addCourseToSession(page, courseE);
+
+    // Second drag to a different session — verify via total (avoids strict-mode
+    // violation from two matching course-box-STG001 elements)
+    const totalStageCredits = page.locator(selectors.totalStageCredits);
+    const courseCard = page.locator(selectors.courseCard(courseA.code));
+    const dropTarget = page.locator(selectors.sessionDropTarget(courseA.sessionTerm, courseA.sessionYear));
+    await dropTarget.scrollIntoViewIfNeeded();
+    await reliableDragAndDrop(page, courseCard, dropTarget, totalStageCredits.filter({ hasText: '18' }));
+
+    await expect(totalStageCredits).toHaveText(
+      `${courseE.credits + courseA.credits} ${STAGE_CREDITS_LABEL}`,
+      { timeout: 15000 },
+    );
+  });
+
+  test('should hide internship credit total when no Stage courses are in the plan', async ({ page }) => {
+    const course = TEST_COURSES.LOG240;
+
+    await searchCourseInSidebar(page, course.code);
+    await addCourseToSession(page, course);
+
+    const totalStageCredits = page.locator(selectors.totalStageCredits);
+
+    await expect(totalStageCredits).not.toBeVisible({ timeout: 15000 });
   });
 });

--- a/tests/unit/creditSplit.test.ts
+++ b/tests/unit/creditSplit.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from 'vitest';
+import { accumulateCreditSplit } from '@/utils/creditUtil';
+
+describe('accumulateCreditSplit', () => {
+  it('counts STAGE courses as internship credits', () => {
+    const courses = {
+      1: { credits: 9, type: 'STAGE' },
+      2: { credits: 3, type: 'TRONC' },
+    };
+    const instances = [{ courseId: 1 }, { courseId: 2 }];
+
+    const result = accumulateCreditSplit(instances, courses);
+
+    expect(result.totalStageCredits).toBe(9);
+    expect(result.totalCourseCredits).toBe(3);
+  });
+
+  it('returns zero internship credits when no STAGE courses are present', () => {
+    const courses = {
+      1: { credits: 3, type: 'TRONC' },
+      2: { credits: 4, type: 'CONCE' },
+    };
+    const instances = [{ courseId: 1 }, { courseId: 2 }];
+
+    const result = accumulateCreditSplit(instances, courses);
+
+    expect(result.totalStageCredits).toBe(0);
+    expect(result.totalCourseCredits).toBe(7);
+  });
+
+  it('returns zero for both when courseInstances is empty', () => {
+    const result = accumulateCreditSplit([], {});
+
+    expect(result.totalCourseCredits).toBe(0);
+    expect(result.totalStageCredits).toBe(0);
+  });
+
+  it('skips course instances whose courseId is not in courses', () => {
+    const courses = {
+      1: { credits: 3, type: 'TRONC' },
+    };
+    const instances = [{ courseId: 1 }, { courseId: 999 }];
+
+    const result = accumulateCreditSplit(instances, courses);
+
+    expect(result.totalCourseCredits).toBe(3);
+    expect(result.totalStageCredits).toBe(0);
+  });
+
+  it('treats courses with null type as regular credits', () => {
+    const courses = {
+      1: { credits: 3, type: null },
+    };
+    const instances = [{ courseId: 1 }];
+
+    const result = accumulateCreditSplit(instances, courses);
+
+    expect(result.totalCourseCredits).toBe(3);
+    expect(result.totalStageCredits).toBe(0);
+  });
+
+  it('treats courses with null credits as 0', () => {
+    const courses = {
+      1: { credits: null, type: 'STAGE' },
+      2: { credits: null, type: 'TRONC' },
+    };
+    const instances = [{ courseId: 1 }, { courseId: 2 }];
+
+    const result = accumulateCreditSplit(instances, courses);
+
+    expect(result.totalStageCredits).toBe(0);
+    expect(result.totalCourseCredits).toBe(0);
+  });
+
+  it('accumulates multiple STAGE courses', () => {
+    const courses = {
+      1: { credits: 9, type: 'STAGE' },
+      2: { credits: 9, type: 'STAGE' },
+      3: { credits: 9, type: 'STAGE' },
+    };
+    const instances = [{ courseId: 1 }, { courseId: 2 }, { courseId: 3 }];
+
+    const result = accumulateCreditSplit(instances, courses);
+
+    expect(result.totalStageCredits).toBe(27);
+    expect(result.totalCourseCredits).toBe(0);
+  });
+});


### PR DESCRIPTION
### ⁉️ Related Issue
<!-- Link the issue this PR addresses, e.g. "Closes #123". Write N/A if none. -->
N/A

## 📖 Description
<!-- Describe what this PR changes and why. -->
- Add STAGE to CourseRequirementType and course type unions
- Add accumulateCreditSplit util to split course vs internship credits by type
- Show a separate internship credits tag in the bottom bar
- remove quality gate for testing code duplication in tests folder
- qol: changed the default placeholder in empty sessions for mobile view to "Tap + to add courses" instead of "drag & drop course here"

### 🧪 How Has This Been Tested?
<!-- Describe the tests you ran to verify your changes. -->
- unit + e2e tests

### ☑️ Checklist before requesting a review
- [x] I have performed a self-review of my code.
- [x] If it is a core feature, I have added thorough tests.

### 🖼️ Screenshots (if useful)
<!-- Add screenshots or screen recordings if they help reviewers. -->
