### PR TITLE
Fix mobile scroll lock for course action menu

### DIFF
--- a/src/components/Planner/CourseActionsMenu.tsx
+++ b/src/components/Planner/CourseActionsMenu.tsx
@@ -37,7 +37,7 @@ export default function CourseActionsMenu({
   const isCourseFavorited = isFavorite(courseId);
 
   return (
-    <DropdownMenu>
+    <DropdownMenu modal={false}>
       <DropdownMenuTrigger asChild>
         <Button
           variant="ghost"

--- a/tests/unit/courseActionsMenu.test.ts
+++ b/tests/unit/courseActionsMenu.test.ts
@@ -1,0 +1,14 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const source = readFileSync(
+  join(process.cwd(), 'src/components/Planner/CourseActionsMenu.tsx'),
+  'utf8',
+);
+
+describe('CourseActionsMenu', () => {
+  it('does not lock page scroll while the course actions dropdown is open', () => {
+    expect(source).toMatch(/<DropdownMenu\s+modal=\{false\}>/);
+  });
+});


### PR DESCRIPTION
## Summary
- Configure the shared course actions dropdown as non-modal so it does not lock document scrolling while open on mobile.
- Add a focused unit guard that keeps the course actions menu using the non-modal dropdown behavior.

## Fixes
Fixes #107

## Verification
- `node` source guard confirmed `CourseActionsMenu` renders `<DropdownMenu modal={false}>`
- `git diff --check`

## Notes
- I attempted to install dependencies with `corepack yarn install --immutable --network-timeout 600000`, but package fetching repeatedly hit network retry failures in this environment.
- Because dependencies could not be installed, `corepack yarn test tests/unit/courseActionsMenu.test.ts` could not run locally (`vitest: command not found`).

This PR was prepared with OpenAI GPT-5 Codex.
