### PR TITLE
respect des variables de langue et améliorations UI

### DIFF
--- a/src/components/Chatbot/ChatInput.tsx
+++ b/src/components/Chatbot/ChatInput.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useTranslations } from 'next-intl';
 import { Send } from 'lucide-react';
 import { useState } from 'react';
 
@@ -12,6 +13,7 @@ type ChatInputProps = {
 export default function ChatInput({
   onSendMessage,
 }: ChatInputProps) {
+  const t = useTranslations('Chatbot');
   const [message, setMessage] = useState('');
 
   const handleSend = () => {
@@ -29,7 +31,7 @@ export default function ChatInput({
         type="text"
         value={message}
         onChange={(e) => setMessage(e.target.value)}
-        placeholder="Écrire un message..."
+        placeholder={t('inputPlaceholder')}
         className="
           flex-1
           rounded-md
@@ -69,3 +71,4 @@ export default function ChatInput({
     </div>
   );
 }
+

--- a/src/components/Chatbot/ChatbotButton.tsx
+++ b/src/components/Chatbot/ChatbotButton.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { Sparkles } from 'lucide-react';
+import { useTranslations } from 'next-intl';
 
 import { Button } from '@/shadcn/ui/button';
 
@@ -13,6 +14,8 @@ export default function ChatbotButton({
   isOpen,
   onClick,
 }: ChatbotButtonProps) {
+  const t = useTranslations('Chatbot');
+
   if (isOpen) {
     return null;
   }
@@ -32,7 +35,7 @@ export default function ChatbotButton({
         "
       >
         <Sparkles className="mr-2 h-4 w-4 text-white" />
-        Assistant PlanifETS
+        {t('buttonLabel')}
       </Button>
     </div>
   );

--- a/src/components/Chatbot/ChatbotPanel.tsx
+++ b/src/components/Chatbot/ChatbotPanel.tsx
@@ -3,11 +3,11 @@
 import type { ChatMessage as ChatMessageType } from './types';
 
 import { Sparkles, X } from 'lucide-react';
-import { useState } from 'react';
+import { useTranslations } from 'next-intl';
+import { useEffect, useState } from 'react';
 import { Button } from '@/shadcn/ui/button';
 import ChatInput from './ChatInput';
 import ChatMessage from './ChatMessage';
-import { mockMessages } from './mock';
 
 type ChatbotPanelProps = {
   onClose: () => void;
@@ -16,8 +16,19 @@ type ChatbotPanelProps = {
 export default function ChatbotPanel({
   onClose,
 }: ChatbotPanelProps) {
-  const [messages, setMessages]
-    = useState<ChatMessageType[]>(mockMessages);
+  const t = useTranslations('Chatbot');
+  const [messages, setMessages] = useState<ChatMessageType[]>([]);
+
+  // Initialize messages with translated initial message
+  useEffect(() => {
+    setMessages([
+      {
+        id: '1',
+        role: 'assistant',
+        content: t('initialMessage'),
+      },
+    ]);
+  }, [t]);
 
   const handleSendMessage = (content: string) => {
     const userMessage: ChatMessageType = {
@@ -33,8 +44,7 @@ export default function ChatbotPanel({
       const assistantMessage: ChatMessageType = {
         id: crypto.randomUUID(),
         role: 'assistant',
-        content:
-          'Ceci est une réponse mockée du chatbot PlanifETS.',
+        content: t('mockResponse'),
       };
 
       setMessages((prev) => [...prev, assistantMessage]);
@@ -73,7 +83,7 @@ export default function ChatbotPanel({
           <Sparkles className="h-5 w-5 text-violet-500 dark:text-violet-300" />
 
           <span className="font-semibold">
-            Assistant PlanifETS
+            {t('buttonLabel')}
           </span>
 
           <span
@@ -89,7 +99,7 @@ export default function ChatbotPanel({
               dark:text-violet-300
             "
           >
-            BETA
+            {t('beta')}
           </span>
         </div>
 
@@ -98,6 +108,7 @@ export default function ChatbotPanel({
           size="icon"
           onClick={onClose}
           data-testid="close-chatbot-button"
+          aria-label={t('closeButtonAriaLabel')}
         >
           <X className="h-4 w-4" />
         </Button>

--- a/src/components/CourseDetails/sections/OfferingsSection.tsx
+++ b/src/components/CourseDetails/sections/OfferingsSection.tsx
@@ -7,7 +7,7 @@ import { useTranslations } from 'next-intl';
 import Tag from '@/components/atoms/Tag';
 import { cn } from '@/shadcn/lib/utils';
 import { buildFutureTimelineOfferings } from '@/utils/offeringsUtil';
-import { getSeasonStyle } from '@/utils/seasonUtil';
+import { getSeasonBorder, getSeasonStyle } from '@/utils/seasonUtil';
 import {
   generateSessionKey,
   getCurrentSession,
@@ -46,8 +46,9 @@ const OfferingsSection = ({
                 <div className="flex w-16 shrink-0 flex-col items-center sm:w-[4.5rem]">
                   <div
                     className={cn(
-                      'relative z-10 flex size-14 shrink-0 flex-col items-center justify-center gap-1 rounded-xl border border-border/70 bg-background px-2 shadow-sm',
-                      isCurrentSession && 'border-primary/60 ring-1 ring-primary/30',
+                      'relative z-10 flex size-14 shrink-0 flex-col items-center justify-center gap-1 rounded-xl border bg-background px-2 shadow-sm',
+                      getSeasonBorder(offering.sessionTerm),
+                      isCurrentSession && 'ring-1 ring-primary/30',
                     )}
                   >
                     <div className="flex items-center justify-center">

--- a/src/components/Planner/Session.tsx
+++ b/src/components/Planner/Session.tsx
@@ -1,12 +1,13 @@
 'use client';
 
 import type { TermEnum } from '@/types/session';
-import { useCallback, useState } from 'react';
 
+import { useCallback, useState } from 'react';
 import { useSessionDrop } from '@/hooks/session/useSessionDrop';
 import { useSessionOperations } from '@/hooks/session/useSessionOperations';
 import { useCourseStore } from '@/store/courseStore';
 import { useSessionStore } from '@/store/sessionStore';
+import { getSeasonBorder } from '@/utils/seasonUtil';
 import { generateSessionKey, isCourseAvailableInSession } from '@/utils/sessionUtil';
 import AddCourseSelector from './AddCourseSelector';
 import CoursesList from './CoursesList';
@@ -37,7 +38,7 @@ export default function Session({
   });
   const getSessionBorderColor = () => {
     if (!draggedItem || !draggedItem.course) {
-      return isOver ? 'border-blue-400' : 'border-border';
+      return isOver ? 'border-blue-400' : getSeasonBorder(sessionTerm);
     }
     if (isKnownSessionAvailability === false) {
       if (isOver) {
@@ -60,7 +61,7 @@ export default function Session({
     if (isOver) {
       return 'border-red-500';
     }
-    return 'border-border';
+    return getSeasonBorder(sessionTerm);
   };
 
   const [showAddCourse, setShowAddCourse] = useState(false);

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -76,6 +76,14 @@
     "remove-from-favorites": "Remove from favorites",
     "add-course": "Tap + to add courses"
   },
+  "Chatbot": {
+    "buttonLabel": "Assistant PlanifETS",
+    "beta": "BETA",
+    "inputPlaceholder": "Write a message...",
+    "initialMessage": "Hello 👋 I'm the PlanifETS assistant. How can I help you?",
+    "mockResponse": "This is a mocked response from the PlanifETS chatbot.",
+    "closeButtonAriaLabel": "Close chatbot"
+  },
   "CourseDetailsPage": {
     "courseOffering": "Offerings",
     "cycle": "cycle",

--- a/src/messages/fr.json
+++ b/src/messages/fr.json
@@ -76,6 +76,14 @@
     "remove-from-favorites": "Retirer des favoris",
     "add-course": "Appuyer sur + pour ajouter des cours"
   },
+  "Chatbot": {
+    "buttonLabel": "Assistant PlanifETS",
+    "beta": "BÊTA",
+    "inputPlaceholder": "Écrire un message...",
+    "initialMessage": "Bonjour 👋 Je suis l'assistant PlanifETS. Comment puis-je vous aider ?",
+    "mockResponse": "Ceci est une réponse mockée du chatbot PlanifETS.",
+    "closeButtonAriaLabel": "Fermer le chatbot"
+  },
   "CourseDetailsPage": {
     "courseOffering": "Disponibilité",
     "cycle": "cycle",

--- a/src/utils/seasonUtil.ts
+++ b/src/utils/seasonUtil.ts
@@ -33,3 +33,36 @@ export const getSeasonStyle = (sessionTerm: string): SeasonStyle => {
 
   return seasonConfig;
 };
+
+export const getSeasonBorder = (sessionTerm: string | TermEnum): string => {
+  // eslint-disable-next-line style/operator-linebreak
+  const season =
+    typeof sessionTerm === 'string'
+      ? ORDERED_SESSION_TERMS.find((s) => sessionTerm.includes(s))
+      : sessionTerm;
+
+  switch (season) {
+    case TermEnum.H:
+      return 'border-2 border-blue-500 dark:border-blue-400';
+    case TermEnum.E:
+      return 'border-2 border-yellow-500 dark:border-yellow-400';
+    case TermEnum.A:
+      return 'border-2 border-orange-500 dark:border-orange-400';
+    default:
+      return 'border border-border';
+  }
+};
+
+export const getSeasonBorderFromTypicalSessionIndex = (
+  typicalSessionIndex: number,
+): string => {
+  if (!Number.isInteger(typicalSessionIndex) || typicalSessionIndex < 1) {
+    return 'border-border';
+  }
+  const index = (typicalSessionIndex - 1) % ORDERED_SESSION_TERMS.length;
+  const seasonTerm = ORDERED_SESSION_TERMS[index];
+  if (!seasonTerm) {
+    return 'border-border';
+  }
+  return getSeasonBorder(seasonTerm);
+};


### PR DESCRIPTION
⁉️ Related Issue
<!-- Link the issue this PR addresses, e.g. "Closes #123". Write N/A if none. -->
N/A

📖 Description
- Added season-based border styling to course offering session badges (H/E/A) using a new `getSeasonBorder()` utility function
  - Winter sessions (H) display with blue borders
  - Summer sessions (E) display with yellow borders  
  - Fall sessions (A) display with orange borders
- Implemented multi-language support (English/French) for chatbot components:
  - ChatbotButton now displays localized button labels
  - ChatbotPanel uses translated messages and header text
  - ChatInput displays localized placeholder text
  - Initial greeting and mock responses adapt to page language
- Added comprehensive translations to `en.json` and `fr.json` message files
- Fixed import ordering and linting issues across modified files

🧪 How Has This Been Tested?
- Frontend: 
  - Tested season border rendering on course offering session cards
  - Verified chatbot components display correctly in both English and French
  - Confirmed responsive language switching when user changes page language

☑️ Checklist before requesting a review
- [x] I have performed a self-review of my code.
- [x] No core feature logic changes; improvements are UI/UX focused
- [x] All TypeScript errors resolved
- [x] Import ordering follows project conventions
- [x] Translation keys added to both localization files

🖼️ Screenshots (if useful)
<!-- Session badge styling with seasonal borders is visible on the course details offerings section -->
<img width="1467" height="547" alt="image" src="https://github.com/user-attachments/assets/7951dd4e-e28f-49dc-92bd-ff50aa98c5ad" />
<img width="892" height="280" alt="image" src="https://github.com/user-attachments/assets/ec6ff56f-8648-4417-a433-58306c91ed14" />
<img width="450" height="752" alt="image" src="https://github.com/user-attachments/assets/5b6c8912-7d52-486c-a8e5-1205a680cb8c" />
