### PR TITLE
ci: add environment-specific image builds

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -9,14 +9,26 @@ on:
   pull_request:
     branches:
       - main
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: Target environment
+        required: true
+        type: choice
+        options:
+          - dev
+          - staging
+          - prod
 
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
+  API_BASE_URL: https://planifets.clubapplets.ca/api
 
 jobs:
   docker:
     runs-on: ubuntu-latest
+    environment: ${{ inputs.environment }}
     permissions:
       contents: read
       packages: write
@@ -33,8 +45,13 @@ jobs:
             type=ref,event=pr,prefix=pr-
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
-            type=sha,prefix=main-,format=short,enable={{is_default_branch}}
-            type=raw,value=latest,enable={{is_default_branch}}
+            type=sha,prefix=main-,format=short,enable=${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+            type=sha,prefix=dev-,format=short,enable=${{ inputs.environment == 'dev' }}
+            type=sha,prefix=staging-,format=short,enable=${{ inputs.environment == 'staging' }}
+            type=sha,prefix=prod-,format=short,enable=${{ inputs.environment == 'prod' }}
+            type=raw,value=dev,enable=${{ inputs.environment == 'dev' }}
+            type=raw,value=staging,enable=${{ inputs.environment == 'staging' }}
+            type=raw,value=latest,enable=${{ inputs.environment == 'prod' }}
 
       - name: Login to Registry
         uses: docker/login-action@v3
@@ -48,6 +65,20 @@ jobs:
         shell: bash
         run: echo "SHORT_SHA=$(git rev-parse --short=7 HEAD)" >> "$GITHUB_ENV"
 
+      - name: Configure target environment
+        if: github.event_name == 'workflow_dispatch'
+        shell: bash
+        env:
+          TARGET_ENVIRONMENT: ${{ inputs.environment }}
+        run: |
+          case "${TARGET_ENVIRONMENT}" in
+            dev) api_base_url=https://planifets.dev.cedille.club/api ;;
+            staging) api_base_url=https://planifets.staging.cedille.club/api ;;
+            prod) api_base_url=https://planifets.clubapplets.ca/api ;;
+            *) echo "Unsupported environment: ${TARGET_ENVIRONMENT}" >&2; exit 1 ;;
+          esac
+          echo "API_BASE_URL=${api_base_url}" >> "$GITHUB_ENV"
+
       - name: Build and push
         uses: docker/build-push-action@v5
         with:
@@ -58,7 +89,7 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
             NEXT_PUBLIC_APP_GIT_SHORT_SHA=${{ env.SHORT_SHA }}
-            NEXT_PUBLIC_API_BASE_URL=https://planifets.prodv2.cedille.club
+            NEXT_PUBLIC_API_BASE_URL=${{ env.API_BASE_URL }}
             NEXT_PUBLIC_POSTHOG_HOST=https://us.i.posthog.com
             NEXT_PUBLIC_POSTHOG_UI_HOST=https://us.posthog.com
             NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN=${{ secrets.NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -29,6 +29,20 @@ For local setup instructions, see [docs/onboarding.md](docs/onboarding.md).
 
 Project documentation and team context are also available in the [docs](docs/).
 
+## Deployment
+
+The `CD` workflow publishes an immutable `main-<sha>` image for each push to `main`. To deploy, run the workflow manually from the tested commit and select `dev`, `staging` or `prod`; it publishes both an immutable environment SHA tag and the mutable tag watched by ArgoCD:
+
+| Environment | Mutable tag | API URL |
+| --- | --- | --- |
+| Development | `dev` | `https://planifets.dev.cedille.club/api` |
+| Staging | `staging` | `https://planifets.staging.cedille.club/api` |
+| Production | `latest` | `https://planifets.clubapplets.ca/api` |
+
+Create matching GitHub Environments before enabling the workflow. Restrict staging and production to `main`, and require reviewers for production. The public analytics identifiers are read from the existing repository secrets.
+
+Unlike the backend, the frontend currently embeds `NEXT_PUBLIC_*` values during the Next.js build. It therefore creates a separate image digest for each environment. Promote the same commit through dev, staging and production; do not retag a dev frontend image for production.
+
 ## ⚖️ License
 
 This project is licensed under the MIT License. See the [LICENSE](https://github.com/ApplETS/planifETS-frontend/blob/main/LICENSE) file for more information.

--- a/README.md
+++ b/README.md
@@ -31,17 +31,7 @@ Project documentation and team context are also available in the [docs](docs/).
 
 ## Deployment
 
-The `CD` workflow publishes an immutable `main-<sha>` image for each push to `main`. To deploy, run the workflow manually from the tested commit and select `dev`, `staging` or `prod`; it publishes both an immutable environment SHA tag and the mutable tag watched by ArgoCD:
-
-| Environment | Mutable tag | API URL |
-| --- | --- | --- |
-| Development | `dev` | `https://planifets.dev.cedille.club/api` |
-| Staging | `staging` | `https://planifets.staging.cedille.club/api` |
-| Production | `latest` | `https://planifets.clubapplets.ca/api` |
-
-Create matching GitHub Environments before enabling the workflow. Restrict staging and production to `main`, and require reviewers for production. The public analytics identifiers are read from the existing repository secrets.
-
-Unlike the backend, the frontend currently embeds `NEXT_PUBLIC_*` values during the Next.js build. It therefore creates a separate image digest for each environment. Promote the same commit through dev, staging and production; do not retag a dev frontend image for production.
+For an in-depth look at how we handle deployments, see [docs/deployment.md](docs/deployment.md).
 
 ## ⚖️ License
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,0 +1,13 @@
+# Deployment Workflows
+
+The `CD` workflow publishes an immutable `main-<sha>` image for each push to `main`. To deploy, run the workflow manually from the tested commit and select `dev`, `staging` or `prod`; it publishes both an immutable environment SHA tag and the mutable tag watched by ArgoCD:
+
+| Environment | Mutable tag | API URL |
+| --- | --- | --- |
+| Development | `dev` | `https://planifets.dev.cedille.club/api` |
+| Staging | `staging` | `https://planifets.staging.cedille.club/api` |
+| Production | `latest` | `https://planifets.clubapplets.ca/api` |
+
+Create matching GitHub Environments before enabling the workflow. Restrict staging and production to `main`, and require reviewers for production. The public analytics identifiers are read from the existing repository secrets.
+
+Unlike the backend, the frontend currently embeds `NEXT_PUBLIC_*` values during the Next.js build. It therefore creates a separate image digest for each environment. Promote the same commit through dev, staging and production; do not retag a dev frontend image for production.


### PR DESCRIPTION
## Summary
- add manual dev, staging, and prod image builds
- publish immutable environment SHA tags plus the tags watched by ArgoCD
- inject the correct public API URL for each Next.js build
- document why frontend images currently differ per environment

## Validation
- actionlint .github/workflows/cd.yml
- YAML parse
- git diff --check

No environment deployment is triggered by this PR.